### PR TITLE
Hcsr04 get sound travel time upgrade and bug fixing

### DIFF
--- a/inc/drivers/HCSR04/HCSR04.h
+++ b/inc/drivers/HCSR04/HCSR04.h
@@ -25,3 +25,4 @@ class HCSR04 {
 };
 
 }  // namespace codal
+

--- a/inc/drivers/HCSR04/HCSR04.h
+++ b/inc/drivers/HCSR04/HCSR04.h
@@ -6,20 +6,22 @@
 namespace codal {
 
 enum class HCSR04Unit : uint8_t {M = 0, Dm = 1, Cm = 2, Mm = 3};
+enum class HCSR04TimeUnit : uint8_t {S = 0, Ms = 1, Us = 2};
 
 class HCSR04 {
   public:
     HCSR04(STM32Pin& trig, STM32Pin& echo) : trig(trig), echo(echo) {};
     ~HCSR04() {};
 
-    uint16_t getDistance(HCSR04Unit type);
-
+    float getDistance(HCSR04Unit type);
+    float getTime(HCSR04TimeUnit type);
 
   private:
     STM32Pin& trig;
     STM32Pin& echo;
 
-    uint16_t getDistanceMilli();
+    float getDistanceMilli();
+    float getTimeMicroSeconds();
 };
 
 }  // namespace codal

--- a/source/drivers/HCSR04/HCSR04.cpp
+++ b/source/drivers/HCSR04/HCSR04.cpp
@@ -38,7 +38,7 @@ float HCSR04::getTime(HCSR04TimeUnit type) {
 }
 
 float HCSR04::getDistanceMilli() { 
-    return static_cast<float>((343000.0 * getTimeMicroSeconds() / 1000000.0) / 2.0);
+    return (343000.0 * getTimeMicroseconds() / 1000000.0) / 2.0;
 }
 
 float HCSR04::getTimeMicroSeconds() { 
@@ -60,6 +60,5 @@ float HCSR04::getTimeMicroSeconds() {
     }
     uint32_t end = micros();
 
-    // Return the time in microsecond
     return static_cast<float>(end - start);
 }

--- a/source/drivers/HCSR04/HCSR04.cpp
+++ b/source/drivers/HCSR04/HCSR04.cpp
@@ -38,7 +38,7 @@ float HCSR04::getTime(HCSR04TimeUnit type) {
 }
 
 float HCSR04::getDistanceMilli() { 
-    return (343000.0 * getTimeMicroseconds() / 1000000.0) / 2.0;
+    return (343000.0 * getTimeMicroSeconds() / 1000000.0) / 2.0;
 }
 
 float HCSR04::getTimeMicroSeconds() { 

--- a/source/drivers/HCSR04/HCSR04.cpp
+++ b/source/drivers/HCSR04/HCSR04.cpp
@@ -5,24 +5,43 @@
 
 using namespace codal;
 
-uint16_t HCSR04::getDistance(HCSR04Unit type) {
+float HCSR04::getDistance(HCSR04Unit type) {
     switch (type)
     {
     case HCSR04Unit::Mm :
         return getDistanceMilli();
     case HCSR04Unit::Cm :
-        return getDistanceMilli() / 10;
+        return getDistanceMilli() / 10.0;
     case HCSR04Unit::Dm :
-        return getDistanceMilli() / 100;
+        return getDistanceMilli() / 100.0;
     case HCSR04Unit::M :
-        return getDistanceMilli() / 1000;
+        return getDistanceMilli() / 1000.0;
     default:
         break;
     }
     return 0;
 }
 
-uint16_t HCSR04::getDistanceMilli() { 
+float HCSR04::getTime(HCSR04TimeUnit type) {
+    switch (type)
+    {
+    case HCSR04TimeUnit::Us :
+        return doublegetTimeMicroSeconds();
+    case HCSR04TimeUnit::Ms :
+        return doublegetTimeMicroSeconds() / 1000.0;
+    case HCSR04TimeUnit::S :
+        return doublegetTimeMicroSeconds() / 1000000.0;
+    default:
+        break;
+    }
+    return 0;
+}
+
+float HCSR04::getDistanceMilli() { 
+    return static_cast<float>((343000.0 * getTimeMicroseconds() / 1000000.0) / 2.0);
+}
+
+float HCSR04::getTimeMicroSeconds() { 
     trig.setDigitalValue(1);
     delay(2);
     trig.setDigitalValue(0);
@@ -41,7 +60,6 @@ uint16_t HCSR04::getDistanceMilli() {
     }
     uint32_t end = micros();
 
-    // Return the distance in millimeter
-    return (343000 * (end - start) / 1000000) / 2;
+    // Return the time in microsecond
+    return static_cast<float>(end - start);
 }
-

--- a/source/drivers/HCSR04/HCSR04.cpp
+++ b/source/drivers/HCSR04/HCSR04.cpp
@@ -26,11 +26,11 @@ float HCSR04::getTime(HCSR04TimeUnit type) {
     switch (type)
     {
     case HCSR04TimeUnit::Us :
-        return doublegetTimeMicroSeconds();
+        return getTimeMicroSeconds();
     case HCSR04TimeUnit::Ms :
-        return doublegetTimeMicroSeconds() / 1000.0;
+        return getTimeMicroSeconds() / 1000.0;
     case HCSR04TimeUnit::S :
-        return doublegetTimeMicroSeconds() / 1000000.0;
+        return getTimeMicroSeconds() / 1000000.0;
     default:
         break;
     }
@@ -38,7 +38,7 @@ float HCSR04::getTime(HCSR04TimeUnit type) {
 }
 
 float HCSR04::getDistanceMilli() { 
-    return static_cast<float>((343000.0 * getTimeMicroseconds() / 1000000.0) / 2.0);
+    return static_cast<float>((343000.0 * getTimeMicroSeconds() / 1000000.0) / 2.0);
 }
 
 float HCSR04::getTimeMicroSeconds() { 


### PR DESCRIPTION
Added the possibility to get the time (in microseconds) of travel of the ultrasonic sound wave produced by the HCSR04 sensor.