### PR TITLE
Add ifdef preproc. for supported target

### DIFF
--- a/inc/drivers/MP34DT01/MP34DT01.h
+++ b/inc/drivers/MP34DT01/MP34DT01.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#ifdef STM32L4xx
 #include <cstdint>
 
 #include "stm32l4xx_hal.h"
@@ -84,3 +85,6 @@ class MP34DT01 {
 };
 
 }  // namespace codal
+#else
+#warning "MP34DT01 is not supported by your target !"
+#endif

--- a/inc/drivers/MP34DT01/MP34DT01_dbmeter.h
+++ b/inc/drivers/MP34DT01/MP34DT01_dbmeter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#ifdef STM32L4xx
 #include "MP34DT01.h"
 #include "Sensor.h"
 
@@ -43,3 +44,7 @@ class MP34DT01_dBMeter : public MP34DT01, public Sensor {
 };
 
 }  // namespace codal
+
+#else
+#warning "MP34DT01 is not supported by your target !"
+#endif

--- a/source/drivers/MP34DT01/MP34DT01.cpp
+++ b/source/drivers/MP34DT01/MP34DT01.cpp
@@ -1,5 +1,6 @@
 #include "MP34DT01.h"
 
+#ifdef STM32L4xx
 #include <cmath>
 #include <list>
 
@@ -257,4 +258,5 @@ void DMA1_Channel4_IRQHandler(void)
 
 #ifdef __cplusplus
 }
+#endif
 #endif


### PR DESCRIPTION
Affiche un warning lors de l'inclusion, mais ne fais rien d'autre.
`#warning "MP34DT01 is not supported by your target !"`