### PR TITLE
Fix APDS driver

### DIFF
--- a/inc/drivers/APDS9960/APDS9960.h
+++ b/inc/drivers/APDS9960/APDS9960.h
@@ -29,6 +29,7 @@ class APDS9960 {
     APDS9960Gain gain;
 
     uint8_t readRegister(uint8_t reg);
+    uint16_t read16BitRegister(uint8_t reg);
     void setRegister(uint8_t reg, uint8_t value);
     uint8_t getBit(uint8_t reg, uint8_t bit) { return (readRegister(reg) >> bit) & 0x01; }
     void setBit(uint8_t reg, uint8_t bit)

--- a/source/drivers/APDS9960/APDS9960.cpp
+++ b/source/drivers/APDS9960/APDS9960.cpp
@@ -1,8 +1,11 @@
 #include "APDS9960.h"
 
+#include "stdio.h"
+
 constexpr uint8_t REG_ENABLE  = 0x80;
 constexpr uint8_t REG_ATIME   = 0x81;
 constexpr uint8_t REG_WTIME   = 0x82;
+constexpr uint8_t REG_CONFIG1 = 0x8D;
 constexpr uint8_t REG_CONTROL = 0x8F;
 constexpr uint8_t REG_STATUS  = 0x93;
 constexpr uint8_t REG_CDATA_L = 0x94;
@@ -19,29 +22,25 @@ using namespace std;
 
 void APDS9960::init()
 {
-    setBit(REG_ENABLE, 0);
-    setBit(REG_ENABLE, 3);
-    setRegister(REG_WTIME, 246);
-
-    setBit(REG_ENABLE, 1);
-    setRegister(REG_ATIME, 219);
+    setRegister(REG_ENABLE, 0b00000001);
+    setRegister(REG_WTIME, 0xFF);
+    setRegister(REG_ATIME, 0xFF);
+    setRegister(REG_CONFIG1, 0b01100000);
     setGain(APDS9960Gain::GAIN_x4);
 }
 
 array<uint16_t, 4> APDS9960::getColors(bool wait)
 {
-    while (getBit(REG_STATUS, 0) == 0)
+    setBit(REG_ENABLE, 1);
+    while (wait && getBit(REG_STATUS, 0) == 0)
         ;
 
-    uint16_t c;
-    uint16_t r;
-    uint16_t g;
-    uint16_t b;
+    uint16_t c = read16BitRegister(REG_CDATA_L);
+    uint16_t r = read16BitRegister(REG_RDATA_L);
+    uint16_t g = read16BitRegister(REG_GDATA_L);
+    uint16_t b = read16BitRegister(REG_BDATA_L);
 
-    c = readRegister(REG_CDATA_L) | (readRegister(REG_CDATA_H) << 8);
-    r = readRegister(REG_RDATA_L) | (readRegister(REG_RDATA_H) << 8);
-    g = readRegister(REG_GDATA_L) | (readRegister(REG_GDATA_H) << 8);
-    b = readRegister(REG_BDATA_L) | (readRegister(REG_BDATA_H) << 8);
+    clearBit(REG_ENABLE, 1);
 
     return {r, g, b, c};
 }
@@ -50,7 +49,7 @@ void APDS9960::setGain(APDS9960Gain gain)
 {
     this->gain  = gain;
     uint8_t reg = readRegister(REG_CONTROL);
-    reg &= 0b11111100;
+    reg &= 0b11001100;
     reg |= (uint8_t)gain;
     setRegister(REG_CONTROL, reg);
 }
@@ -58,6 +57,12 @@ void APDS9960::setGain(APDS9960Gain gain)
 uint8_t APDS9960::readRegister(uint8_t reg)
 {
     return i2c.readRegister(address, reg, 1)[0];
+}
+
+uint16_t APDS9960::read16BitRegister(uint8_t reg)
+{
+    auto regs = i2c.readRegister(address, reg, 2);
+    return (uint16_t(regs[1]) << 8) | uint16_t(regs[0]);
 }
 
 void APDS9960::setRegister(uint8_t reg, uint8_t value)


### PR DESCRIPTION
Le principal problème était la lecture des registres de donnée en deux temps... (pourtant c'était écrit dans la datasheet...mais je ne sais pas lire...)