### PR TITLE
Fix warning overloaded-virtual

### DIFF
--- a/inc/STM32I2C.h
+++ b/inc/STM32I2C.h
@@ -102,6 +102,7 @@ class STM32I2C : public codal::I2C {
      * @param value byte to send
      */
     void writeRegister(uint8_t reg, uint8_t value);
+    using I2C::writeRegister;
 
     /**
      * @brief Read data from slave
@@ -123,6 +124,7 @@ class STM32I2C : public codal::I2C {
      * @return bytes received from slave
      */
     std::vector<uint8_t> readRegister(uint8_t address, uint8_t reg, size_t len, bool sendStop = true);
+    using I2C::readRegister;
 
     /**
      * Issues a standard, I2C command write to the I2C bus.
@@ -142,6 +144,7 @@ class STM32I2C : public codal::I2C {
      * @return DEVICE_OK on success, DEVICE_I2C_ERROR if the the write request failed.
      */
     virtual int write(uint16_t address, uint8_t* data, int len, bool repeated = false) override final;
+    using I2C::write;
 
     /**
      * Issues a standard, 2 byte I2C command read to the I2C bus.
@@ -161,6 +164,8 @@ class STM32I2C : public codal::I2C {
      * @return DEVICE_OK on success, DEVICE_I2C_ERROR if the the read request failed.
      */
     virtual int read(uint16_t address, uint8_t* data, int len, bool repeated = false) override final;
+
+    using I2C::read;
 
   private:
     /**

--- a/source/drivers/VL53L1X/vl53l1x_class.cpp
+++ b/source/drivers/VL53L1X/vl53l1x_class.cpp
@@ -775,7 +775,8 @@ VL53L1X_ERROR VL53L1X_base::VL53L1X_StartTemperatureUpdate()
 
 int8_t VL53L1X_base::VL53L1X_CalibrateOffset(uint16_t TargetDistInMm, int16_t* offset)
 {
-    uint8_t i               = 0, tmp;
+    uint8_t i               = 0;
+    uint8_t tmp             = 0;
     int16_t AverageDistance = 0;
     uint16_t distance;
     VL53L1X_ERROR status = 0;


### PR DESCRIPTION
Fix the warning overloaded-virtual by making visible in derived class the method hidden due to no redefinition.